### PR TITLE
Search in the correct bundle for resource bundle

### DIFF
--- a/Classes/NSBundle+CTFeedback.m
+++ b/Classes/NSBundle+CTFeedback.m
@@ -5,6 +5,8 @@
 
 #import "NSBundle+CTFeedback.h"
 
+#import "CTFeedbackViewController.h"
+
 @implementation NSBundle (CTFeedback)
 
 + (NSBundle *)feedbackBundle
@@ -13,7 +15,8 @@
     static dispatch_once_t predicate;
 
     dispatch_once(&predicate, ^{
-        NSURL *bundleURL = [[NSBundle mainBundle] URLForResource:@"CTFeedback" withExtension:@"bundle"];
+        NSBundle *classBundle = [NSBundle bundleForClass:[CTFeedbackViewController class]];
+        NSURL *bundleURL = [classBundle URLForResource:@"CTFeedback" withExtension:@"bundle"];
 
         if (bundleURL) {
             bundle = [NSBundle bundleWithURL:bundleURL];


### PR DESCRIPTION
If CTFeedback is built as a framework, the resource bundle will be in the framework and not the main bundle. The code has been updated to find the correct bundle containing the resource bundler.