### PR TITLE
Fix empty AppName bug

### DIFF
--- a/Classes/CTFeedbackViewController.m
+++ b/Classes/CTFeedbackViewController.m
@@ -300,7 +300,9 @@ typedef NS_ENUM(NSInteger, CTFeedbackSection){
 
 - (NSString *)appName
 {
-    return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+    return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]?
+    [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]:
+    [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
 }
 
 - (NSString *)appVersion


### PR DESCRIPTION
CFBundleDisplayName can be nil sometimes