### PR TITLE
iPad compatibility + cancel button if in navigation controller

### DIFF
--- a/Classes/CTFeedbackViewController.m
+++ b/Classes/CTFeedbackViewController.m
@@ -108,9 +108,16 @@ typedef NS_ENUM(NSInteger, CTFeedbackSection){
         self.navigationController.navigationBarHidden = NO;
     }
 
-    if (self.presentingViewController.presentedViewController) {
-        self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelButtonTapped:)];
-    }
+	if(self.navigationController != nil){
+		if( [self.navigationController viewControllers][0] == self){
+			self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelButtonTapped:)];
+		}else{
+			// Keep the standard back button instead of "Cancel"
+			self.navigationItem.leftBarButtonItem = nil;
+		}
+	} else {
+		self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelButtonTapped:)];
+	}
 }
 
 - (void)didReceiveMemoryWarning

--- a/Classes/CTFeedbackViewController.m
+++ b/Classes/CTFeedbackViewController.m
@@ -38,6 +38,7 @@ typedef NS_ENUM(NSInteger, CTFeedbackSection){
 @property (nonatomic, readonly) NSString *mailBody;
 @property (nonatomic, readonly) NSData *mailAttachment;
 @property (nonatomic, assign) BOOL previousNavigationBarHiddenState;
+@property (nonatomic, strong) UIPopoverController *popoverController;
 @end
 
 @implementation CTFeedbackViewController
@@ -520,10 +521,27 @@ static NSString * const ATTACHMENT_FILENAME = @"screenshot.jpg";
     controller.sourceType = sourceType;
     controller.allowsEditing = YES;
     controller.delegate = self;
-    [self presentViewController:controller animated:YES completion:nil];
+	
+	if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+		if ([UIPopoverPresentationController class]) {
+			controller.modalPresentationStyle = UIModalPresentationPopover;
+			
+			UIPopoverPresentationController *presentationController = [controller popoverPresentationController];
+			presentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
+			presentationController.sourceView = self.view;
+			presentationController.sourceRect = self.view.frame;
+			
+			[self presentViewController:controller animated:YES completion:nil];
+		} else {
+			self.popoverController = [[UIPopoverController alloc] initWithContentViewController:controller];
+			[self.popoverController presentPopoverFromRect:self.view.frame inView:self.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+		}
+	} else {
+		[self presentViewController:controller animated:YES completion:nil];
+	}
 }
 
-- (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex {
+- (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex {
     UIImagePickerControllerSourceType sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
     if (buttonIndex == 0) {
         // camera
@@ -540,22 +558,34 @@ static NSString * const ATTACHMENT_FILENAME = @"screenshot.jpg";
 
 #pragma mark - UIImagePickerControllerDelegate
 - (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info {
-    [picker dismissViewControllerAnimated:YES completion:^() {
-        NSIndexPath *indexPath = [NSIndexPath indexPathForRow:0 inSection:CTFeedbackSectionScreenshot];
-        CTFeedbackAdditionInfoCellItem *cellItem = self.cellItems[(NSUInteger)indexPath.section][(NSUInteger)indexPath.row];
-
-        UIImage *image = [info objectForKey:UIImagePickerControllerEditedImage];
-        if (image == nil){
+	
+	void (^block)() = ^{
+		NSIndexPath *indexPath = [NSIndexPath indexPathForRow:0 inSection:CTFeedbackSectionScreenshot];
+		CTFeedbackAdditionInfoCellItem *cellItem = self.cellItems[(NSUInteger)indexPath.section][(NSUInteger)indexPath.row];
+		
+		UIImage *image = [info objectForKey:UIImagePickerControllerEditedImage];
+		if (image == nil){
 			image = [info objectForKey:UIImagePickerControllerOriginalImage];
-        }
-        cellItem.screenImage = image;
-        //        cellItem.value = [[info objectForKey:@"UIImagePickerControllerReferenceURL"] absoluteString];
-        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
-    }];
+		}
+		cellItem.screenImage = image;
+		//        cellItem.value = [[info objectForKey:@"UIImagePickerControllerReferenceURL"] absoluteString];
+		[self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+	};
+	
+	if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad && ![UIPopoverPresentationController class]) {
+		[self.popoverController dismissPopoverAnimated:YES];
+		block();
+	} else {
+		[picker dismissViewControllerAnimated:YES completion:block];
+	}
 }
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
-    [picker dismissViewControllerAnimated:YES completion:nil];
+	if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad && ![UIPopoverPresentationController class]) {
+		[self.popoverController dismissPopoverAnimated:YES];
+	} else {
+		[picker dismissViewControllerAnimated:YES completion:nil];
+	}
 }
 
 #pragma mark - camera utility

--- a/Resources/fr.lproj/CTFeedbackLocalizable.strings
+++ b/Resources/fr.lproj/CTFeedbackLocalizable.strings
@@ -42,7 +42,7 @@
 
 "Additional Info" = "Informations complémentaires";
 
-"Additional detail" = "Selectioner une pièce-jointe (image)";
+"Additional detail" = "Sélectionner une pièce-jointe (image)";
 
 "Cancel" = "Annuler";
 

--- a/Resources/fr.lproj/CTFeedbackLocalizable.strings
+++ b/Resources/fr.lproj/CTFeedbackLocalizable.strings
@@ -1,0 +1,51 @@
+/* Localizable.strings
+  CTFeedbackDemo
+
+  Created by Ryoichi Izumita on 2013/10/31.
+  Copyright (c) 2013 CAPH. All rights reserved. */
+
+"Question" = "Question";
+
+"Request" = "Requête";
+
+"Bug Report" = "Rapport de bug";
+
+"Other" = "Autre";
+
+"Device" = "Appareil";
+
+"iOS" = "iOS";
+
+"Name" = "Nom";
+
+"Version" = "Version";
+
+"Build" = "Build";
+
+"Device Info" = "Informations sur l'appareil";
+
+"App Info" = "Informations sur l'application";
+
+"Feedback" = "Support";
+
+"Topic" = "Sujet";
+
+"Topics" = "Sujets";
+
+"Error" = "Error";
+
+"Mail" = "Mail";
+
+"Mail no configuration" = "Vous n'avez pas configuré de compte mail";
+
+"Dismiss" = "Fermer";
+
+"Additional Info" = "Informations complémentaires";
+
+"Additional detail" = "Selectioner une pièce-jointe (image)";
+
+"Cancel" = "Annuler";
+
+"Camera" = "Appareil photo";
+
+"PhotoLibrary" = "Sélectionner depuis l'album";


### PR DESCRIPTION
Hi,

This pull request fixes to problems in CTFeedback :

1. The image picker was not displayed when trying to add an attachement on iPad. Image picker is now presented in a Popover (with compatibility support for systems lower than iOS 8).

2. When the controller was pushed in a navigation controller, "Cancel" was displayed instead of the back button. In this case, the back button is now displayed.

Thanks a lot