### PR TITLE
Present UIImagePickerController after UIActionSheet has been dismissed

### DIFF
--- a/Classes/CTFeedbackViewController.m
+++ b/Classes/CTFeedbackViewController.m
@@ -592,7 +592,7 @@ static NSString * const ATTACHMENT_FILENAME = @"screenshot.jpg";
     [self presentViewController:controller animated:YES completion:nil];
 }
 
-- (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex {
+- (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex {
     UIImagePickerControllerSourceType sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
     if (buttonIndex == 0) {
         // camera


### PR DESCRIPTION
When on iPad with iOS 8 or later, UIActionSheet will use UIAlertController. We then have to make sure the UIAlertController is dismissed before we present the UIImagePickerController, or it won't be presented.