### PR TITLE
Fix bug: we cannot select  photo with iPad

### DIFF
--- a/CTFeedbackDemo/CTFeedbackDemo/Base.lproj/Main_iPad.storyboard
+++ b/CTFeedbackDemo/CTFeedbackDemo/Base.lproj/Main_iPad.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="15A284" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="fVr-u0-bsW">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="fVr-u0-bsW">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <scenes>
         <!--Navigation Controller-->
@@ -11,7 +11,6 @@
                 <navigationController definesPresentationContext="YES" id="fVr-u0-bsW" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="5U6-FI-O5o">
                         <autoresizingMask key="autoresizingMask"/>
-                        <animations/>
                     </navigationBar>
                     <connections>
                         <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="LiJ-lE-enh"/>
@@ -35,7 +34,6 @@
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GVv-jM-4Ku">
                                 <rect key="frame" x="350" y="472" width="68" height="30"/>
-                                <animations/>
                                 <state key="normal" title="Feedback">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
@@ -45,20 +43,27 @@
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="giX-T5-FHZ">
                                 <rect key="frame" x="318" y="552" width="132" height="30"/>
-                                <animations/>
                                 <state key="normal" title="Feedback (custom)"/>
                                 <connections>
                                     <action selector="customFeebackButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ELk-9R-hlF"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Cbx-pr-9Ot">
+                                <rect key="frame" x="321" y="632" width="126" height="30"/>
+                                <state key="normal" title="Feedback (simple)"/>
+                                <connections>
+                                    <action selector="simpleFeebackButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="imD-1t-7Zo"/>
+                                </connections>
+                            </button>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="giX-T5-FHZ" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="08K-kz-q5p"/>
                             <constraint firstItem="GVv-jM-4Ku" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="-25" id="7BE-sr-0TG"/>
+                            <constraint firstItem="Cbx-pr-9Ot" firstAttribute="top" secondItem="giX-T5-FHZ" secondAttribute="bottom" constant="50" id="NT9-U2-xPj"/>
                             <constraint firstItem="giX-T5-FHZ" firstAttribute="top" secondItem="GVv-jM-4Ku" secondAttribute="bottom" constant="50" id="WsK-Qb-JOn"/>
                             <constraint firstItem="GVv-jM-4Ku" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="pTm-nl-GvL"/>
+                            <constraint firstItem="Cbx-pr-9Ot" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="xGm-9J-e5K"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="CTFeedback Demo" id="tmU-JK-A9P"/>

--- a/CTFeedbackDemo/CTFeedbackDemo/Base.lproj/Main_iPhone.storyboard
+++ b/CTFeedbackDemo/CTFeedbackDemo/Base.lproj/Main_iPhone.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="ItC-AB-PrL">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="ItC-AB-PrL">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>

--- a/Classes/CTFeedbackViewController.m
+++ b/Classes/CTFeedbackViewController.m
@@ -604,7 +604,7 @@ static NSString * const ATTACHMENT_FILENAME = @"screenshot.jpg";
 	
 	if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
 		if ([UIPopoverPresentationController class]) {
-			controller.modalPresentationStyle = UIModalPresentationPopover;
+			controller.modalPresentationStyle = UIModalPresentationFormSheet;
 			
 			UIPopoverPresentationController *presentationController = [controller popoverPresentationController];
 			presentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;


### PR DESCRIPTION
Bug fix:

- we cannot select  photo with iPad when use pushViewController.

![simulator screen shot 2016 02 03 23 58 59](https://cloud.githubusercontent.com/assets/391549/12787241/eab3cdaa-cad7-11e5-8cd4-a68d5ccf8466.png)

In Japanese:
iPadでpushViewControllerを使って画面遷移すると画像のようにpop overが選択できませんでした。
`controller.modalPresentationStyle = UIModalPresentationFormSheet;` を指定して画面中央に表示させました。